### PR TITLE
Add documentation about JSON structure of requirements

### DIFF
--- a/docs/en/mod/json/reference/json_info.md
+++ b/docs/en/mod/json/reference/json_info.md
@@ -612,6 +612,77 @@ an `"anything"` constraint on it. For example:
 This is a simple "survive a day" but is triggered by waking up, so it will be completed when you
 wake up for the first time after 24 hours into the game.
 
+### `requirements`
+The requirements system in Cataclysm defines reusable sets of components, tools, and qualities needed for crafting, construction, and other game mechanics. Requirements are defined in JSON format and located in `data/json/requirements/`.
+
+## JSON Structure
+
+### Basic Format
+```json
+{
+  "id": "unique_id",
+  "type": "requirement",
+  "//": "Optional comment",
+  "components": [ /* materials consumed */ ],
+  "tools": [ /* items used but not consumed */ ],
+  "qualities": [ /* minimum tool quality levels */ ]
+}
+```
+
+#### Format
+Any of the three last arrays is optional, as long as one of them is present (a requirement must depend on *something* after all!)
+
+**Components** are organized as nested arrays representing alternatives and requirements:
+
+```json
+"components": [
+  [ /* Group 1: ONE of these required */ ],
+  [ /* Group 2: ONE of these required */ ]
+]
+```
+
+- `[ "item_id", quantity ]` - Specific item
+- `[ "item_id", quantity, "LIST" ]` - References another requirement definition
+
+**Tools** specify items that are used but not consumed, along with charge costs:
+
+```json
+"tools": [
+  [
+    [ "tool_id", charges ],
+    [ "alternative", charges, "LIST" ]
+  ]
+]
+```
+
+`charges` can be a positive integer, in which case it references the number of charges consumed, or `-1` to signify that no charges are used.
+
+**Qualities** specify minimum tool quality levels needed:
+
+```json
+"qualities": [
+  { "id": "QUALITY_ID", "level": min_level }
+]
+
+#### Usage in Recipes
+
+Here is an example of a requirement in a recipe:
+
+```json
+"using": [ [ "requirement_id", multiplier ] ]
+```
+
+Multiple requirements:
+```json
+"using": [
+  [ "welding_standard", 1 ],
+  [ "forging_standard", 2 ]
+]
+```
+
+You can explore the files in the `/data/json/requirements` folder to see common examples of requirements for certain types of items or components. Make sure that your requirements do not form any circular dependencies.
+
+
 ### Skills
 
 ```json


### PR DESCRIPTION
I added a section about requirements and a few lines about the syntax of the "LIST" option, as described in #8 