### PR TITLE
docs: Add documentation for requirements and list format

### DIFF
--- a/docs/en/mod/json/reference/json_info.md
+++ b/docs/en/mod/json/reference/json_info.md
@@ -612,6 +612,77 @@ an `"anything"` constraint on it. For example:
 This is a simple "survive a day" but is triggered by waking up, so it will be completed when you
 wake up for the first time after 24 hours into the game.
 
+### `requirements`
+The requirements system in Cataclysm defines reusable sets of components, tools, and qualities needed for crafting, construction, and other game mechanics. Requirements are defined in JSON format and located in `data/json/requirements/`.
+
+## JSON Structure
+
+### Basic Format
+```json
+{
+  "id": "unique_id",
+  "type": "requirement",
+  "//": "Optional comment",
+  "components": [ /* materials consumed */ ],
+  "tools": [ /* items used but not consumed */ ],
+  "qualities": [ /* minimum tool quality levels */ ]
+}
+```
+
+#### Format
+Any of the three last arrays is optional, as long as one of them is present (a requirement must depend on *something* after all!)
+
+**Components** are organized as nested arrays representing alternatives and requirements:
+
+```json
+"components": [
+  [ /* Group 1: ONE of these required */ ],
+  [ /* Group 2: ONE of these required */ ]
+]
+```
+
+- `[ "item_id", quantity ]` - Specific item
+- `[ "item_id", quantity, "LIST" ]` - References another requirement definition
+
+**Tools** specify items that are used but not consumed, along with charge costs:
+
+```json
+"tools": [
+  [
+    [ "tool_id", charges ],
+    [ "alternative", charges, "LIST" ]
+  ]
+]
+```
+
+`charges` can be a positive integer, in which case it references the number of charges consumed, or `-1` to signify that no charges are used.
+
+**Qualities** specify minimum tool quality levels needed:
+
+```json
+"qualities": [
+  { "id": "QUALITY_ID", "level": min_level }
+]
+
+#### Usage in Recipes
+
+Here is an example of a requirement in a recipe:
+
+```json
+"using": [ [ "requirement_id", multiplier ] ]
+```
+
+Multiple requirements:
+```json
+"using": [
+  [ "welding_standard", 1 ],
+  [ "forging_standard", 2 ]
+]
+```
+
+You can explore the files in the `/data/json/requirements` folder to see common examples of requirements for certain types of items or components. Make sure that your requirements do not form any circular dependencies.
+
+
 ### Skills
 
 ```json

--- a/docs/en/mod/json/reference/json_info.md
+++ b/docs/en/mod/json/reference/json_info.md
@@ -626,22 +626,22 @@ The requirements system in Cataclysm defines reusable sets of components, tools,
   "type": "requirement",
   "//": "Optional comment",
   "components": [
-     [
-        [ "gasoline", 1 ],
-        [ "diesel", 1 ],
-        [ "biodiesel", 1 ]
-     ]
+    [
+      ["gasoline", 1],
+      ["diesel", 1],
+      ["biodiesel", 1]
+    ]
   ],
   "tools": [
-     [
-        [ "soldering_iron", 1 ],
-        [ "soldering_ethanol", 10 ],
-        [ "toolset", 1 ]
-     ]
+    [
+      ["soldering_iron", 1],
+      ["soldering_ethanol", 10],
+      ["toolset", 1]
+    ]
   ],
   "qualities": [
-      { "id": "CUT", "level": 1 },
-      { "id": "HAMMER", "level": 2 },
+    { "id": "CUT", "level": 1 },
+    { "id": "HAMMER", "level": 2 }
   ]
 }
 ```

--- a/docs/en/mod/json/reference/json_info.md
+++ b/docs/en/mod/json/reference/json_info.md
@@ -613,24 +613,27 @@ This is a simple "survive a day" but is triggered by waking up, so it will be co
 wake up for the first time after 24 hours into the game.
 
 ### `requirements`
+
 The requirements system in Cataclysm defines reusable sets of components, tools, and qualities needed for crafting, construction, and other game mechanics. Requirements are defined in JSON format and located in `data/json/requirements/`.
 
 ## JSON Structure
 
 ### Basic Format
+
 ```json
 {
   "id": "unique_id",
   "type": "requirement",
   "//": "Optional comment",
-  "components": [ /* materials consumed */ ],
-  "tools": [ /* items used but not consumed */ ],
-  "qualities": [ /* minimum tool quality levels */ ]
+  "components": [/* materials consumed */],
+  "tools": [/* items used but not consumed */],
+  "qualities": [/* minimum tool quality levels */]
 }
 ```
 
 #### Format
-Any of the three last arrays is optional, as long as one of them is present (a requirement must depend on *something* after all!)
+
+Any of the three last arrays is optional, as long as one of them is present (a requirement must depend on _something_ after all!)
 
 **Components** are organized as nested arrays representing alternatives and requirements:
 
@@ -659,7 +662,7 @@ Any of the three last arrays is optional, as long as one of them is present (a r
 
 **Qualities** specify minimum tool quality levels needed:
 
-```json
+````json
 "qualities": [
   { "id": "QUALITY_ID", "level": min_level }
 ]
@@ -670,9 +673,10 @@ Here is an example of a requirement in a recipe:
 
 ```json
 "using": [ [ "requirement_id", multiplier ] ]
-```
+````
 
 Multiple requirements:
+
 ```json
 "using": [
   [ "welding_standard", 1 ],
@@ -681,7 +685,6 @@ Multiple requirements:
 ```
 
 You can explore the files in the `/data/json/requirements` folder to see common examples of requirements for certain types of items or components. Make sure that your requirements do not form any circular dependencies.
-
 
 ### Skills
 

--- a/docs/en/mod/json/reference/json_info.md
+++ b/docs/en/mod/json/reference/json_info.md
@@ -625,9 +625,24 @@ The requirements system in Cataclysm defines reusable sets of components, tools,
   "id": "unique_id",
   "type": "requirement",
   "//": "Optional comment",
-  "components": [/* materials consumed */],
-  "tools": [/* items used but not consumed */],
-  "qualities": [/* minimum tool quality levels */]
+  "components": [
+     [
+        [ "gasoline", 1 ],
+        [ "diesel", 1 ],
+        [ "biodiesel", 1 ]
+     ]
+  ],
+  "tools": [
+     [
+        [ "soldering_iron", 1 ],
+        [ "soldering_ethanol", 10 ],
+        [ "toolset", 1 ]
+     ]
+  ],
+  "qualities": [
+      { "id": "CUT", "level": 1 },
+      { "id": "HAMMER", "level": 2 },
+  ]
 }
 ```
 


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Add missing documentation for requirements in recipes. Resolves #8

## Describe the solution (The How)

Adds a small section to `docs/en/mod/json/reference/json_info.md` about requirements

## Describe alternatives you've considered

## Testing

No testing should be required

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->

No optional checkboxes are affected by this PR
