### PR TITLE
fix: insert meat into smoker with hammerspace enabled

### DIFF
--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1550,10 +1550,6 @@ std::vector<detached_ptr<item>> Character::consume_items( map &m,
 {
     std::vector<detached_ptr<item>> ret;
 
-    if( has_trait( trait_DEBUG_HS ) ) {
-        return ret;
-    }
-
     item_comp selected_comp = is.comp;
 
     const tripoint &loc = origin;
@@ -1581,7 +1577,7 @@ std::vector<detached_ptr<item>> Character::consume_items( map &m,
                         std::make_move_iterator( tmp.end() ) );
         }
     }
-    if( is.use_from & usage_from::player ) {
+    if( is.use_from & usage_from::player && ! has_trait( trait_DEBUG_HS ) ) {
         if( by_charges ) {
             std::vector<detached_ptr<item>> tmp = use_charges( selected_comp.type, real_count, filter );
             ret.insert( ret.end(), std::make_move_iterator( tmp.begin() ),

--- a/src/crafting.cpp
+++ b/src/crafting.cpp
@@ -1552,11 +1552,23 @@ std::vector<detached_ptr<item>> Character::consume_items( map &m,
 
     item_comp selected_comp = is.comp;
 
-    const tripoint &loc = origin;
     const bool by_charges = item::count_by_charges( selected_comp.type ) && selected_comp.count > 0;
     // Count given to use_amount/use_charges, changed by those functions!
     int real_count = ( selected_comp.count > 0 ) ? selected_comp.count * batch : std::abs(
-                         selected_comp.count );
+        selected_comp.count );
+
+    if( has_trait( trait_DEBUG_HS ) ) {
+        if( by_charges ) {
+            ret.push_back( item::spawn( selected_comp.type, calendar::start_of_cataclysm, real_count ) );
+        } else {
+            for( int i = 0; i < real_count; i++ ) {
+                ret.push_back( item::spawn( selected_comp.type ) );
+            }
+        }
+        return ret;
+    }
+
+    const tripoint &loc = origin;
     // First try to get everything from the map, than (remaining amount) from player
     if( is.use_from & usage_from::map ) {
         if( by_charges ) {


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Solves #5: unable to insert meat into smoker when hammerspace is enabled

## Describe the solution (The How)

Modify the check to see if hammerspace is enabled in method `consume_items` of file `src/crafting.cpp`

## Describe alternatives you've considered

## Testing

Using the provided save I tried inserting meat into the smoker with Hammerspace on and off. Insertion works in both cases.

## Additional context

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->


