### PR TITLE
fix: reduce combat skill rust rate if PRED2/3/4 are active

### DIFF
--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4274,7 +4274,7 @@ void Character::do_skill_rust()
         const int oldSkillLevel = skill_level_obj.level();
 
         // default multiplier is 1; if PRED2/3/4 are enabled, reduce the multiplier accordingly
-        int rust_rate_multiplier = 1;
+        float rust_rate_multiplier = 1;
 
         if ( aSkill.is_combat_skill() ) {
             if ( has_trait_flag( trait_flag_PRED2 ) ) {

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4243,7 +4243,7 @@ void Character::apply_skill_boost()
 
 void Character::do_skill_rust()
 {
-    int rust_rate_tmp = rust_rate();
+    const int rust_rate_tmp = rust_rate();
     for( std::pair<const skill_id, SkillLevel> &pair : *_skills ) {
         const Skill &aSkill = *pair.first;
         SkillLevel &skill_level_obj = pair.second;
@@ -4273,15 +4273,20 @@ void Character::do_skill_rust()
                                      has_active_bionic( bio_memory );
         const int oldSkillLevel = skill_level_obj.level();
 
-        // if the current skill is a combat skill and PRED2/3/4 are active, reduce rust rate by 20%
-        if( aSkill.is_combat_skill() &&
-            ( has_trait_flag( trait_flag_PRED2 ) ||
-              has_trait_flag( trait_flag_PRED3 ) ||
-              has_trait_flag( trait_flag_PRED4 ) ) ) {
-            rust_rate_tmp = rust_rate_tmp * 0.8;
+        // default multiplier is 1; if PRED2/3/4 are enabled, reduce the multiplier accordingly
+        int rust_rate_multiplier = 1;
+
+        if ( aSkill.is_combat_skill() ) {
+            if ( has_trait_flag( trait_flag_PRED2 ) ) {
+                rust_rate_multiplier = 0.8;
+            } else if ( has_trait_flag( trait_flag_PRED3 ) ) {
+                rust_rate_multiplier = 0.6;
+            } else if ( has_trait_flag( trait_flag_PRED4 ) ) {
+                rust_rate_multiplier = 0.4;
+            }
         }
 
-        if( skill_level_obj.rust( charged_bio_mem, rust_rate_tmp ) ) {
+        if( skill_level_obj.rust( charged_bio_mem, rust_rate_tmp * rust_rate_multiplier ) ) {
             add_msg_if_player( m_warning,
                                _( "Your knowledge of %s begins to fade, but your memory banks retain it!" ), aSkill.name() );
             mod_power_level( -bio_memory->power_trigger );

--- a/src/character.cpp
+++ b/src/character.cpp
@@ -4243,7 +4243,7 @@ void Character::apply_skill_boost()
 
 void Character::do_skill_rust()
 {
-    const int rust_rate_tmp = rust_rate();
+    int rust_rate_tmp = rust_rate();
     for( std::pair<const skill_id, SkillLevel> &pair : *_skills ) {
         const Skill &aSkill = *pair.first;
         SkillLevel &skill_level_obj = pair.second;
@@ -4272,6 +4272,15 @@ void Character::do_skill_rust()
         const bool charged_bio_mem = get_power_level() > bio_memory->power_trigger &&
                                      has_active_bionic( bio_memory );
         const int oldSkillLevel = skill_level_obj.level();
+
+        // if the current skill is a combat skill and PRED2/3/4 are active, reduce rust rate by 20%
+        if( aSkill.is_combat_skill() &&
+            ( has_trait_flag( trait_flag_PRED2 ) ||
+              has_trait_flag( trait_flag_PRED3 ) ||
+              has_trait_flag( trait_flag_PRED4 ) ) ) {
+            rust_rate_tmp = rust_rate_tmp * 0.8;
+        }
+
         if( skill_level_obj.rust( charged_bio_mem, rust_rate_tmp ) ) {
             add_msg_if_player( m_warning,
                                _( "Your knowledge of %s begins to fade, but your memory banks retain it!" ), aSkill.name() );


### PR DESCRIPTION
<!-- for small, obvious fixes (e.g docs), it's okay to ignore this template -->

## Purpose of change (The Why)

Resolves #7

## Describe the solution (The How)

Reduces rust rate of combat skills by 20% if PRED3, PRED3 or PRED4 are active

## Describe alternatives you've considered

## Testing

<!-- Describe what steps you took to test that this PR resolved the bug or added the feature, and what tests you performed to make sure it didn't cause any regressions. Also include testing suggestions for reviewers and maintainers. -->

## Additional context

<!-- Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here. -->

## Checklist

<!--
NOTE: Please grant permission for repository maintainers to edit your PR.  It is EXTREMELY common for PRs to be held up due to trivial changes being requested and the author being unavailable to make them.  In web UI, you can do it by clicking the "Allow edits and access to secrets by maintainers" checkbox next to "Create Pull Request" button at the bottom of the editor, or by clicking the same checkbox in the sidebar after PR has been created.

NOTE: Please read your emails. Anyone mentioned on Github with an @ will receive an email, any activity on your work will also send emails. This is more reliable than being notified on our Discord, you will always get an email.
--->

### Mandatory

- [x] I wrote the PR title in [conventional commit format](https://docs.cataclysmbn.org/contribute/changelog_guidelines/).
- [x] I ran the [code formatter](https://docs.cataclysmbn.org/contribute/contributing/#code-style).
- [x] I linked any relevant issues using [github keyword syntax](https://docs.cataclysmbn.org/contribute/contributing/#pull-request-notes) like `closes #1234` in [Summary of the PR](#purpose-of-change-the-why) so it can be closed automatically.
- [x] I've [committed my changes to new branch that isn't `main`](https://docs.cataclysmbn.org/contribute/contributing/#make-your-changes) so it won't cause conflict when updating `main` branch later.

### Optional

<!-- please remove checkboxes unrelated to this PR. -->
